### PR TITLE
INFRA-9023 Update `aws_route53_zone` resource for Multi-VPC Support

### DIFF
--- a/modules/zones/CHANGELOG.md
+++ b/modules/zones/CHANGELOG.md
@@ -9,3 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated `aws_route53_zone` resource configuration to handle multiple hosted zones with the same domain name by modifying the `for_each` key to include the `vpc_id` where applicable.
 - Programmatically updated the Terraform state to reflect the new `for_each` keys, preventing resource recreation.
+
+## [4.0.0] - 2024-08-30
+Points to the upstream tag without changes https://github.com/terraform-aws-modules/terraform-aws-route53/releases/tag/v4.0.0

--- a/modules/zones/CHANGELOG.md
+++ b/modules/zones/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.1] - 2024-08-30
+### Changed
+- Updated `aws_route53_zone` resource configuration to handle multiple hosted zones with the same domain name by modifying the `for_each` key to include the `vpc_id` where applicable.
+- Programmatically updated the Terraform state to reflect the new `for_each` keys, preventing resource recreation.

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,6 +1,7 @@
 resource "aws_route53_zone" "this" {
-  for_each = { for k, v in var.zones : k => v if var.create }
-
+  for_each = {
+    for k, v in var.zones : "${k}-${lookup(try(v.vpc[0], {}), "vpc_id", "global")}" => v if var.create
+  }
   name          = lookup(each.value, "domain_name", each.key)
   comment       = lookup(each.value, "comment", null)
   force_destroy = lookup(each.value, "force_destroy", false)


### PR DESCRIPTION
## Description
This PR updates the Terraform configuration to handle multiple AWS Route 53 private-hosted zones with the same domain name but different VPCs. The changes include:

- Modification of for_each Key: The aws_route53_zone resource now uses a for_each key that combines the domain name with the associated vpc_id (if applicable). This ensures unique identifiers for each hosted zone, even when the domain names are the same across different VPCs. If vpc_id value does not exist we will append global to the domain. 
- State File Update: To prevent Terraform from recreating existing resources due to the change in the for_each key, the Terraform state will be programmatically updated. Existing hosted zones will be moved from their old state keys (based solely on domain names) to new state keys (based on domain names and VPC IDs).
- Script for State Migration: A script was created and executed to facilitate the state update, ensuring a smooth transition without downtime.
## Impact
- No Downtime: The update will be applied programmatically, avoiding any need to destroy and recreate existing resources, thus preventing potential downtime.
- State Consistency: The Terraform state will be successfully updated, ensuring that future Terraform operations correctly identify and manage existing resources.
## Additional Notes
- Verification: After applying these changes, a terraform plan and terraform apply should be run to verify that no unintended changes are introduced and that the infrastructure remains consistent with the desired state.
- Related Changelog Entry
[4.0.1] - 2024-08-30

Please review the changes and provide any feedback. Once approved, this PR will be merged and we will start using the module in the dev account followed by production.