### PR TITLE
INFRA-9023 Update Resource Addressing for Route 53 Zones 

### DIFF
--- a/modules/zones/CHANGELOG.md
+++ b/modules/zones/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2024-09-02
+### Changed
+- Refined the `aws_route53_zone` resource configuration by updating the `for_each` key to include a SHA256 hash of the JSON-encoded configuration for each hosted zone. This change ensures unique resource addresses and prevents conflicts when managing multiple hosted zones.
+- Updated Terraform outputs to reference the new resource addresses, ensuring consistency across the configuration.
+
 ## [4.0.1] - 2024-08-30
 ### Changed
 - Updated `aws_route53_zone` resource configuration to handle multiple hosted zones with the same domain name by modifying the `for_each` key to include the `vpc_id` where applicable.

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,13 +1,8 @@
 locals {
-  # Create a map with unique keys by adding a suffix to duplicate domain names
+  # Create a map with unique keys by adding a hash of the domain name
   unique_zones = {
-    for idx, zone in flatten([
-      for key, value in var.zones : {
-        key   = key
-        value = value
-      }
-    ]) :
-    "${zone.key}_${idx}" => merge(zone.value, { original_key = zone.key })
+    for key, value in var.zones :
+    "${key}_${sha256(key)}" => merge(value, { original_key = key })
   }
 }
 

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -8,7 +8,7 @@ locals {
 resource "aws_route53_zone" "this" {
   for_each = { for k, v in local.unique_zones : k => v if var.create }
 
-  name          = each.key
+  name          = lookup(each.value, "domain_name", each.value.original_key)
   comment       = lookup(each.value, "comment", null)
   force_destroy = lookup(each.value, "force_destroy", false)
 

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -1,30 +1,29 @@
-# Updated outputs
 output "route53_zone_zone_id" {
   description = "Zone ID of Route53 zone"
-  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].zone_id }
+  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].zone_id }
 }
 
 output "route53_zone_zone_arn" {
   description = "Zone ARN of Route53 zone"
-  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].arn }
+  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].arn }
 }
 
 output "route53_zone_name_servers" {
   description = "Name servers of Route53 zone"
-  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].name_servers }
+  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].name_servers }
 }
 
 output "primary_name_server" {
   description = "The Route 53 name server that created the SOA record."
-  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].primary_name_server }
+  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].primary_name_server }
 }
 
 output "route53_zone_name" {
   description = "Name of Route53 zone"
-  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].name }
+  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].name }
 }
 
 output "route53_static_zone_name" {
   description = "Name of Route53 zone created statically to avoid invalid count argument error when creating records and zones simultaneously"
-  value       = { for k, v in var.zones : k => lookup(v, "domain_name", k) if var.create }
+  value       = { for k, v in local.unique_zones : k => v.domain_name if var.create }
 }

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -1,29 +1,29 @@
 output "route53_zone_zone_id" {
   description = "Zone ID of Route53 zone"
-  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].zone_id }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(jsonencode(v))}"].zone_id }
 }
 
 output "route53_zone_zone_arn" {
   description = "Zone ARN of Route53 zone"
-  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].arn }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(jsonencode(v))}"].arn }
 }
 
 output "route53_zone_name_servers" {
   description = "Name servers of Route53 zone"
-  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].name_servers }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(jsonencode(v))}"].name_servers }
 }
 
 output "primary_name_server" {
   description = "The Route 53 name server that created the SOA record."
-  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].primary_name_server }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(jsonencode(v))}"].primary_name_server }
 }
 
 output "route53_zone_name" {
   description = "Name of Route53 zone"
-  value       = { for k, v in local.unique_zones : k => aws_route53_zone.this[k].name }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(jsonencode(v))}"].name }
 }
 
 output "route53_static_zone_name" {
   description = "Name of Route53 zone created statically to avoid invalid count argument error when creating records and zones simultaneously"
-  value       = { for k, v in local.unique_zones : k => v.domain_name if var.create }
+  value       = { for k, v in var.zones : k => lookup(v, "domain_name", k) if var.create }
 }

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -1,29 +1,30 @@
+# Updated outputs
 output "route53_zone_zone_id" {
   description = "Zone ID of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.zone_id }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].zone_id }
 }
 
 output "route53_zone_zone_arn" {
   description = "Zone ARN of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.arn }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].arn }
 }
 
 output "route53_zone_name_servers" {
   description = "Name servers of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.name_servers }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].name_servers }
 }
 
 output "primary_name_server" {
   description = "The Route 53 name server that created the SOA record."
-  value       = { for k, v in aws_route53_zone.this : k => v.primary_name_server }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].primary_name_server }
 }
 
 output "route53_zone_name" {
   description = "Name of Route53 zone"
-  value       = { for k, v in aws_route53_zone.this : k => v.name }
+  value       = { for k, v in var.zones : k => aws_route53_zone.this["${k}_${sha256(k)}"].name }
 }
 
 output "route53_static_zone_name" {
-  description = "Name of Route53 zone created statically to avoid invalid count argument error when creating records and zones simmultaneously"
+  description = "Name of Route53 zone created statically to avoid invalid count argument error when creating records and zones simultaneously"
   value       = { for k, v in var.zones : k => lookup(v, "domain_name", k) if var.create }
 }

--- a/modules/zones/versions.tf
+++ b/modules/zones/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.36.0"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "3.6.2"
+    }
   }
 }

--- a/modules/zones/versions.tf
+++ b/modules/zones/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.36.0"
     }
-    random = {
-      source = "hashicorp/random"
-      version = "3.6.2"
-    }
   }
 }


### PR DESCRIPTION
https://github.com/verygood-ops/terraform-aws-route53/pull/1 did not work as expected as it was not honoring the domain name. This PR fixes this.

I have already tested and it works well in DEV https://github.com/verygood-ops/infrastructure-live/pull/4568

Changes:
- Unique Resource Addressing: The resource addresses for aws_route53_zone resources now include a SHA256 hash based on the JSON-encoded configuration of each hosted zone rather than just the hosted zone name. This ensures that each resource is uniquely identifiable based on its full configuration.
- Local Computation of Keys: A local variable unique_zones was introduced, which computes a unique key for each hosted zone using the new hashing method. This key is then used in the for_each loop to create aws_route53_zone resources.
- Outputs Updated: Corresponding output variables (route53_zone_zone_id, route53_zone_zone_arn, etc.) have been updated to reference the new resource address format.